### PR TITLE
Added querying by suspended customers (true and false cases)

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -149,3 +149,9 @@ class Customer(db.Model):
         """Returns a Customer with the given phone number"""
         logger.info("Processing phone_number query for %s ...", phone_number)
         return cls.query.filter(cls.phone_number == phone_number).first()
+
+    @classmethod
+    def find_by_suspended(cls, suspended):
+        """Returns all Customers with the given suspended status"""
+        logger.info("Processing suspended query for %s ...", suspended)
+        return cls.query.filter(cls.suspended == suspended).all()

--- a/service/routes.py
+++ b/service/routes.py
@@ -54,6 +54,8 @@ def index():
                 "update": url_for("update_customers", customer_id=1, _external=True),
                 "delete": url_for("delete_customers", customer_id=1, _external=True),
                 "find_by_email": url_for("list_customers", _external=True),
+                "suspend": url_for("suspend_customer", customer_id=1, _external=True),
+                "activate": url_for("activate_customer", customer_id=1, _external=True),
             },
         ),
         status.HTTP_200_OK,
@@ -180,6 +182,7 @@ def list_customers():
     first_name = request.args.get("first_name")
     last_name = request.args.get("last_name")
     phone_number = request.args.get("phone_number")
+    suspended = request.args.get("suspended")  # ADD THIS LINE
 
     # Start with base query
     query = Customer.query
@@ -200,6 +203,12 @@ def list_customers():
     if phone_number:
         app.logger.info("Find by phone_number: %s", phone_number)
         query = query.filter(Customer.phone_number == phone_number)
+
+    if suspended is not None:
+        # Convert string to boolean (handles 'true', 'false', '1', '0', etc.)
+        suspended_bool = suspended.lower() in ('true', '1', 'yes')
+        app.logger.info("Find by suspended: %s", suspended_bool)
+        query = query.filter(Customer.suspended == suspended_bool)
 
     # Execute the query to get filtered results
     customers = query.all()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -378,3 +378,50 @@ class TestModelQueries(TestCase):
         """It should return None when phone number not found"""
         found = Customer.find_by_phone_number("999-999-9999")
         self.assertIsNone(found)
+
+    def test_find_by_suspended_true(self):
+        """It should Find Customers that are suspended"""
+        customers = CustomerFactory.create_batch(5)
+        # Make some customers suspended
+        customers[0].suspended = True
+        customers[2].suspended = True
+        for customer in customers:
+            customer.create()
+        found = Customer.find_by_suspended(True)
+        self.assertEqual(len(found), 2)
+        for customer in found:
+            self.assertTrue(customer.suspended)
+
+    def test_find_by_suspended_false(self):
+        """It should Find Customers that are not suspended"""
+        customers = CustomerFactory.create_batch(5)
+        # Make some customers suspended, leave others active
+        customers[1].suspended = True
+        customers[3].suspended = True
+        for customer in customers:
+            customer.create()
+
+        found = Customer.find_by_suspended(False)
+        self.assertEqual(len(found), 3)
+        for customer in found:
+            self.assertFalse(customer.suspended)
+
+    def test_find_by_suspended_all_active(self):
+        """It should return all customers when all are active"""
+        customers = CustomerFactory.create_batch(3)
+        # All customers active by default
+        for customer in customers:
+            customer.create()
+
+        found = Customer.find_by_suspended(False)
+        self.assertEqual(len(found), 3)
+
+    def test_find_by_suspended_none_suspended(self):
+        """It should return empty list when no customers are suspended"""
+        customers = CustomerFactory.create_batch(3)
+        # All customers active by default
+        for customer in customers:
+            customer.create()
+
+        found = Customer.find_by_suspended(True)
+        self.assertEqual(len(found), 0)


### PR DESCRIPTION
1. Added query filters for first_name, last_name, phone_number, and suspended status with support for multiple parameter combinations
2. implemented suspend and activate actions to manage customer account status via PUT endpoints
3. All query parameters work together (e.g., GET /customers?first_name=John&suspended=true) enabling flexible customer searches