### PR TITLE
Configure GitHub webhook route for Tekton pipeline integration

### DIFF
--- a/.tekton/webhook-route.yaml
+++ b/.tekton/webhook-route.yaml
@@ -1,0 +1,12 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: github-webhook-route
+spec:
+  to:
+    kind: Service
+    name: el-cd-listener
+  port:
+    targetPort: http-listener
+  tls:
+    termination: edge


### PR DESCRIPTION
 Add webhook route to expose EventListener externally
- Enables GitHub webhooks to trigger CD pipeline on master branch pushes
-  Configure GitHub Webhook to Trigger Tekton Pipeline